### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -8,7 +8,7 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-CT		KEYWORD1
+CT	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
@@ -16,9 +16,9 @@ CT		KEYWORD1
 read	KEYWORD2
 calibrate	KEYWORD2
 getRawData	KEYWORD2
-getMax	    KEYWORD2
-getMin   KEYWORD2
-getOffset   KEYWORD2
+getMax	KEYWORD2
+getMin	KEYWORD2
+getOffset	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords